### PR TITLE
Fix: Correct Gemini API Key Initialization for Image and Video Services

### DIFF
--- a/services/backend/src/app/services/text2image_service.py
+++ b/services/backend/src/app/services/text2image_service.py
@@ -26,7 +26,7 @@ class Text2ImageService:
 
     def __init__(self):
         """Initializes the Text2ImageService, creating the output directory if needed."""
-        self.client = genai.Client()
+        self.client = genai.Client(api_key=settings.GEMINI_API_KEY)
         self.output_dir = settings.IMAGE_OUTPUT_DIR
         os.makedirs(self.output_dir, exist_ok=True)
 

--- a/services/backend/src/app/services/text2video_service.py
+++ b/services/backend/src/app/services/text2video_service.py
@@ -25,7 +25,7 @@ class Text2VideoService:
 
     def __init__(self):
         """Initializes the Text2VideoService."""
-        self.client = genai.Client()
+        self.client = genai.Client(api_key=settings.GEMINI_API_KEY)
         self.output_dir = settings.VIDEO_OUTPUT_DIR
         os.makedirs(self.output_dir, exist_ok=True)
 


### PR DESCRIPTION
**Description:**
This pull request addresses a critical `ValueError: Missing key inputs argument!` that occurred when initializing the `google.generativeai.Client()` within `Text2ImageService` and `Text2VideoService`.

**Problem:**
The `Text2ImageService` and `Text2VideoService` were attempting to instantiate `genai.Client()` without providing the `api_key` argument, leading to a `ValueError` at runtime. While the `GeminiService` correctly used `settings.GEMINI_API_KEY`, these specific services were not leveraging the central configuration for API key management. This resulted in internal server errors when trying to generate images or videos.

**Solution:**
The fix involves explicitly passing `settings.GEMINI_API_KEY` to the `genai.Client()` constructor within the `__init__` methods of both `Text2ImageService` and `Text2VideoService`. This ensures that these services are properly authenticated when making calls to the Google Generative AI API.

**Changes Made:**
- Modified `src/app/services/text2image_service.py`: Updated `self.client = genai.Client()` to `self.client = genai.Client(api_key=settings.GEMINI_API_KEY)`.
- Modified `src/app/services/text2video_service.py`: Updated `self.client = genai.Client()` to `self.client = genai.Client(api_key=settings.GEMINI_API_KEY)`.

**Impact:**
This change resolves the `500 Internal Server Error` encountered during text-to-image and text-to-video generation, making these functionalities operational.
